### PR TITLE
Conditional resource highlighting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.3'
+def runeLiteVersion = '1.8.33.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -491,6 +491,15 @@ public interface TheGauntletConfig extends Config
 		return 1;
 	}
 
+	@ConfigItem(
+		name = "Remove outline once acquired",
+		description = "Remove the outline for resources once they have been acquired",
+		position = 19,
+		keyName = "resourceRemoveOutlineOnceAcquired",
+		section = "resourceOverlay"
+	)
+	default boolean resourceRemoveOutlineOnceAcquired() { return false; }
+
 	// Utilities Section
 
 	@ConfigItem(

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -498,7 +498,7 @@ public interface TheGauntletConfig extends Config
 		keyName = "resourceRemoveOutlineOnceAcquired",
 		section = "resourceOverlay"
 	)
-	default boolean resourceRemoveOutlineOnceAcquired() { return false; }
+	default boolean resourceRemoveOutlineOnceAcquired() { return true; }
 
 	// Utilities Section
 

--- a/src/main/java/ca/gauntlet/TheGauntletPlugin.java
+++ b/src/main/java/ca/gauntlet/TheGauntletPlugin.java
@@ -30,8 +30,8 @@
 
 package ca.gauntlet;
 
-import ca.gauntlet.entity.Resource;
-import ca.gauntlet.entity.Resource.ResourceType;
+import ca.gauntlet.entity.ResourceEntity;
+import ca.gauntlet.entity.ResourceEntity.ResourceType;
 import ca.gauntlet.overlay.SceneOverlay;
 import ca.gauntlet.overlay.TimerOverlay;
 import ca.gauntlet.resource.ResourceManager;
@@ -105,13 +105,13 @@ public class TheGauntletPlugin extends Plugin
 	);
 
 	@Getter
-	private final Set<Resource> resources = new HashSet<>();
+	private final Set<ResourceEntity> resourceEntities = new HashSet<>();
 	@Getter
 	private final Set<GameObject> utilities = new HashSet<>();
 	@Getter
 	private final Set<NPC> tornadoes = new HashSet<>();
 
-	private final List<Set<?>> entitySets = Arrays.asList(resources, utilities, tornadoes);
+	private final List<Set<?>> entitySets = Arrays.asList(resourceEntities, utilities, tornadoes);
 
 	@Inject
 	private Client client;
@@ -193,7 +193,7 @@ public class TheGauntletPlugin extends Plugin
 			case LOADING:
 				if (inGauntlet)
 				{
-					resources.clear();
+					resourceEntities.clear();
 					utilities.clear();
 				}
 				break;
@@ -215,89 +215,89 @@ public class TheGauntletPlugin extends Plugin
 		switch (event.getKey())
 		{
 			case "oreDepositOutlineColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.ORE_DEPOSIT))
 						.forEach(r -> r.setOutlineColor(config.oreDepositOutlineColor()));
 				}
 				break;
 			case "oreDepositFillColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.ORE_DEPOSIT))
 						.forEach(r -> r.setFillColor(config.oreDepositFillColor()));
 				}
 				break;
 			case "phrenRootsOutlineColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.PHREN_ROOTS))
 						.forEach(r -> r.setOutlineColor(config.phrenRootsOutlineColor()));
 				}
 				break;
 			case "phrenRootsFillColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.PHREN_ROOTS))
 						.forEach(r -> r.setFillColor(config.phrenRootsFillColor()));
 				}
 				break;
 			case "linumTirinumOutlineColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.LINUM_TIRINUM))
 						.forEach(r -> r.setOutlineColor(config.linumTirinumOutlineColor()));
 				}
 				break;
 			case "linumTirinumFillColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.LINUM_TIRINUM))
 						.forEach(r -> r.setFillColor(config.linumTirinumFillColor()));
 				}
 				break;
 			case "grymRootOutlineColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.GRYM_ROOT))
 						.forEach(r -> r.setOutlineColor(config.grymRootOutlineColor()));
 				}
 				break;
 			case "grymRootFillColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.GRYM_ROOT))
 						.forEach(r -> r.setFillColor(config.grymRootFillColor()));
 				}
 				break;
 			case "fishingSpotOutlineColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.FISHING_SPOT))
 						.forEach(r -> r.setOutlineColor(config.fishingSpotOutlineColor()));
 				}
 				break;
 			case "fishingSpotFillColor":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.stream()
+					resourceEntities.stream()
 						.filter(r -> r.isResourceType(ResourceType.FISHING_SPOT))
 						.forEach(r -> r.setFillColor(config.fishingSpotFillColor()));
 				}
 				break;
 			case "resourceIconSize":
-				if (!resources.isEmpty())
+				if (!resourceEntities.isEmpty())
 				{
-					resources.forEach(r -> r.setIconSize(config.resourceIconSize()));
+					resourceEntities.forEach(r -> r.setIconSize(config.resourceIconSize()));
 				}
 				break;
 			case "resourceTracker":
@@ -435,7 +435,7 @@ public class TheGauntletPlugin extends Plugin
 					throw new IllegalArgumentException("Unsupported resource id: " + id);
 			}
 
-			resources.add(new Resource(resourceType, gameObject, skillIconManager, config.resourceIconSize(), outlineColor, fillColor));
+			resourceEntities.add(new ResourceEntity(resourceType, gameObject, skillIconManager, config.resourceIconSize(), outlineColor, fillColor));
 		}
 		else if (UTILITY_IDS.contains(id))
 		{
@@ -457,7 +457,7 @@ public class TheGauntletPlugin extends Plugin
 
 		if (RESOURCE_IDS.contains(gameObject.getId()))
 		{
-			resources.removeIf(o -> o.getGameObject() == gameObject);
+			resourceEntities.removeIf(o -> o.getGameObject() == gameObject);
 		}
 		else if (UTILITY_IDS.contains(id))
 		{

--- a/src/main/java/ca/gauntlet/entity/Resource.java
+++ b/src/main/java/ca/gauntlet/entity/Resource.java
@@ -61,7 +61,13 @@ public class Resource
 	@Setter
 	private Color fillColor;
 
-	public Resource(final ResourceType resourceType, final GameObject gameObject, final SkillIconManager skillIconManager, final int iconSize, final Color outlineColor, final Color fillColor)
+	public Resource(
+		final ResourceType resourceType,
+		final GameObject gameObject,
+		final SkillIconManager skillIconManager,
+		final int iconSize,
+		final Color outlineColor,
+		final Color fillColor)
 	{
 		this.resourceType = resourceType;
 		this.gameObject = gameObject;

--- a/src/main/java/ca/gauntlet/entity/ResourceEntity.java
+++ b/src/main/java/ca/gauntlet/entity/ResourceEntity.java
@@ -37,7 +37,7 @@ import net.runelite.api.Skill;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.util.ImageUtil;
 
-public class Resource
+public class ResourceEntity
 {
 	private static final int DEFAULT_ICON_SIZE = 14;
 
@@ -61,7 +61,7 @@ public class Resource
 	@Setter
 	private Color fillColor;
 
-	public Resource(
+	public ResourceEntity(
 		final ResourceType resourceType,
 		final GameObject gameObject,
 		final SkillIconManager skillIconManager,

--- a/src/main/java/ca/gauntlet/overlay/SceneOverlay.java
+++ b/src/main/java/ca/gauntlet/overlay/SceneOverlay.java
@@ -29,7 +29,7 @@ package ca.gauntlet.overlay;
 
 import ca.gauntlet.TheGauntletConfig;
 import ca.gauntlet.TheGauntletPlugin;
-import ca.gauntlet.entity.Resource;
+import ca.gauntlet.entity.ResourceEntity;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -135,27 +135,27 @@ public class SceneOverlay extends Overlay
 
 	private void renderResources(final Graphics2D graphics2D)
 	{
-		if (!config.overlayResources() || plugin.getResources().isEmpty())
+		if (!config.overlayResources() || plugin.getResourceEntities().isEmpty())
 		{
 			return;
 		}
 
 		final LocalPoint localPointPlayer = player.getLocalLocation();
 
-		for (final Resource resource : plugin.getResources())
+		for (final ResourceEntity resourceEntity : plugin.getResourceEntities())
 		{
-			if (!isOverlayEnabled(resource))
+			if (!isOverlayEnabled(resourceEntity))
 			{
 				continue;
 			}
 
 			if (config.resourceRemoveOutlineOnceAcquired()
-				&& hasAcquiredResource(resource))
+				&& this.resourceManager.hasAcquiredResource(resourceEntity))
 			{
 				continue;
 			}
 
-			final GameObject gameObject = resource.getGameObject();
+			final GameObject gameObject = resourceEntity.getGameObject();
 
 			final LocalPoint localPointGameObject = gameObject.getLocalLocation();
 
@@ -166,7 +166,7 @@ public class SceneOverlay extends Overlay
 
 			if (config.resourceHullOutlineWidth() > 0)
 			{
-				modelOutlineRenderer.drawOutline(gameObject, config.resourceHullOutlineWidth(), resource.getOutlineColor(), 1);
+				modelOutlineRenderer.drawOutline(gameObject, config.resourceHullOutlineWidth(), resourceEntity.getOutlineColor(), 1);
 			}
 
 			if (config.resourceTileOutlineWidth() > 0)
@@ -175,46 +175,15 @@ public class SceneOverlay extends Overlay
 
 				if (polygon != null)
 				{
-					drawOutlineAndFill(graphics2D, resource.getOutlineColor(), resource.getFillColor(),
+					drawOutlineAndFill(graphics2D, resourceEntity.getOutlineColor(), resourceEntity.getFillColor(),
 						config.resourceTileOutlineWidth(), polygon);
 				}
 			}
 
 			if (config.resourceIconSize() > 0)
 			{
-				OverlayUtil.renderImageLocation(client, graphics2D, localPointGameObject, resource.getIcon(), 0);
+				OverlayUtil.renderImageLocation(client, graphics2D, localPointGameObject, resourceEntity.getIcon(), 0);
 			}
-		}
-	}
-
-	private boolean hasAcquiredResource(Resource resource)
-	{
-		switch (resource.getGameObject().getId())
-		{
-			case ObjectID.CRYSTAL_DEPOSIT:
-				return this.resourceManager.getResourceCount("Crystal ore") < 1;
-
-			case ObjectID.CORRUPT_DEPOSIT:
-				return this.resourceManager.getResourceCount("Corrupted ore") < 1;
-
-			case ObjectID.PHREN_ROOTS:
-			case ObjectID.PHREN_ROOTS_36066:
-				return this.resourceManager.getResourceCount("Phren bark") < 1;
-
-			case ObjectID.LINUM_TIRINUM:
-			case ObjectID.LINUM_TIRINUM_36072:
-				return this.resourceManager.getResourceCount("Linum tirinum") < 1;
-
-			case ObjectID.GRYM_ROOT:
-			case ObjectID.GRYM_ROOT_36070:
-				return this.resourceManager.getResourceCount("Grym leaf") < 1;
-
-			case ObjectID.FISHING_SPOT_36068:
-			case ObjectID.FISHING_SPOT_35971:
-				return this.resourceManager.getResourceCount("Raw paddlefish") < 1;
-
-			default:
-				return false;
 		}
 	}
 
@@ -243,9 +212,9 @@ public class SceneOverlay extends Overlay
 		return localPoint.distanceTo(playerLocation) >= config.renderDistance().getDistance();
 	}
 
-	private boolean isOverlayEnabled(final Resource resource)
+	private boolean isOverlayEnabled(final ResourceEntity resourceEntity)
 	{
-		switch (resource.getGameObject().getId())
+		switch (resourceEntity.getGameObject().getId())
 		{
 			case ObjectID.CRYSTAL_DEPOSIT:
 			case ObjectID.CORRUPT_DEPOSIT:

--- a/src/main/java/ca/gauntlet/resource/Resource.java
+++ b/src/main/java/ca/gauntlet/resource/Resource.java
@@ -36,7 +36,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ItemID;
 
-enum Resource
+public enum Resource
 {
 	TELEPORT_CRYSTAL("Teleport crystal", ItemID.TELEPORT_CRYSTAL, false),
 	CORRUPTED_TELEPORT_CRYSTAL("Corrupted teleport crystal", ItemID.CORRUPTED_TELEPORT_CRYSTAL, true),

--- a/src/main/java/ca/gauntlet/resource/Resource.java
+++ b/src/main/java/ca/gauntlet/resource/Resource.java
@@ -36,7 +36,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.api.ItemID;
 
-public enum Resource
+enum Resource
 {
 	TELEPORT_CRYSTAL("Teleport crystal", ItemID.TELEPORT_CRYSTAL, false),
 	CORRUPTED_TELEPORT_CRYSTAL("Corrupted teleport crystal", ItemID.CORRUPTED_TELEPORT_CRYSTAL, true),

--- a/src/main/java/ca/gauntlet/resource/Resource.java
+++ b/src/main/java/ca/gauntlet/resource/Resource.java
@@ -72,6 +72,7 @@ enum Resource
 
 	private static final Resource[] VALUES = Resource.values();
 
+	@Getter(AccessLevel.PACKAGE)
 	private final String name;
 
 	@Getter(AccessLevel.PACKAGE)

--- a/src/main/java/ca/gauntlet/resource/ResourceCounter.java
+++ b/src/main/java/ca/gauntlet/resource/ResourceCounter.java
@@ -70,6 +70,8 @@ class ResourceCounter extends InfoBox
 		return Color.WHITE;
 	}
 
+	public int getCount() { return this.count; }
+
 	@Subscribe
 	void onResourceEvent(final ResourceEvent event)
 	{

--- a/src/main/java/ca/gauntlet/resource/ResourceManager.java
+++ b/src/main/java/ca/gauntlet/resource/ResourceManager.java
@@ -30,6 +30,8 @@ package ca.gauntlet.resource;
 
 import ca.gauntlet.TheGauntletConfig;
 import ca.gauntlet.TheGauntletPlugin;
+
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -55,6 +57,8 @@ public class ResourceManager
 	private static final Pattern PATTERN_RESOURCE_DROP = Pattern.compile("((?<quantity>\\d+) x )?(?<name>.+)");
 
 	private final Set<Resource> resources = new HashSet<>();
+
+	private final HashMap<String, ResourceCounter> resourceCounters = new HashMap<>();
 
 	@Inject
 	private Client client;
@@ -91,6 +95,8 @@ public class ResourceManager
 
 		resources.clear();
 
+		resourceCounters.clear();
+
 		infoBoxManager.getInfoBoxes()
 			.stream()
 			.filter(ResourceCounter.class::isInstance)
@@ -124,6 +130,16 @@ public class ResourceManager
 		resources.remove(resourceCounter.getResource());
 		eventBus.unregister(resourceCounter);
 		infoBoxManager.removeInfoBox(resourceCounter);
+	}
+
+	public int getResourceCount(final String resourceName)
+	{
+		if (!this.resourceCounters.containsKey(resourceName))
+		{
+			return 0;
+		}
+
+		return this.resourceCounters.get(resourceName).getCount();
 	}
 
 	private void processNpcResource(final String parsedMessage)
@@ -185,6 +201,7 @@ public class ResourceManager
 				itemManager.getImage(resource.getItemId()), count, plugin, this);
 			eventBus.register(resourceCounter);
 			infoBoxManager.addInfoBox(resourceCounter);
+			resourceCounters.put(resource.getName(), resourceCounter);
 		}
 		else
 		{

--- a/src/main/java/ca/gauntlet/resource/ResourceManager.java
+++ b/src/main/java/ca/gauntlet/resource/ResourceManager.java
@@ -139,6 +139,11 @@ public class ResourceManager
 	{
 		Resource resource = this.getResourceFromObjectId(resourceEntity.getGameObject().getId());
 
+		if (resource == null)
+		{
+			return false;
+		}
+
 		return this.getResourceCount(resource) < 1;
 	}
 
@@ -291,29 +296,28 @@ public class ResourceManager
 		switch (objectId)
 		{
 			case ObjectID.CRYSTAL_DEPOSIT:
-				return Resource.fromName("Crystal ore", false);
+				return Resource.CRYSTAL_ORE;
 			case ObjectID.CORRUPT_DEPOSIT:
-				return Resource.fromName("Corrupted ore", true);
+				return Resource.CORRUPTED_ORE;
 
 			case ObjectID.PHREN_ROOTS_36066:
-				return Resource.fromName("Phren bark", false);
+				return Resource.PHREN_BARK;
 			case ObjectID.PHREN_ROOTS:
-				return Resource.fromName("Phren bark", true);
+				return Resource.CORRUPTED_PHREN_BARK;
 
 			case ObjectID.LINUM_TIRINUM_36072:
-				return Resource.fromName("Linum tirinum", false);
+				return Resource.LINUM_TIRINUM;
 			case ObjectID.LINUM_TIRINUM:
-				return Resource.fromName("Linum tirinum", true);
+				return Resource.CORRUPTED_LINUM_TIRINUM;
 
 			case ObjectID.GRYM_ROOT_36070:
-				return Resource.fromName("Grym leaf", false);
+				return Resource.GRYM_LEAF;
 			case ObjectID.GRYM_ROOT:
-				return Resource.fromName("Grym leaf", true);
+				return Resource.CORRUPTED_GRYM_LEAF;
 
-			case ObjectID.FISHING_SPOT_36068:
-				return Resource.fromName("Raw paddlefish", false);
 			case ObjectID.FISHING_SPOT_35971:
-				return Resource.fromName("Raw paddlefish", true);
+			case ObjectID.FISHING_SPOT_36068:
+				return Resource.RAW_PADDLEFISH;
 
 			default:
 				return null;


### PR DESCRIPTION
This pull request adds a setting to remove the highlighting of resources  once they have been acquired in a run, thus making it easier to spot resources that still need to be obtained.

![java_rwdwLTafKf](https://user-images.githubusercontent.com/10182579/193355553-129a8db8-11ce-43be-a1a5-3d9f9aa5031a.gif)

The toggle-able setting can be found at the end of the `Resource Overlay` section.

I had to expose several class methods to make it possible to get the current resource count in the `SceneOverlay` class, let me know if it's a problem.

I'm participating in the 2022 [Hacktoberfest](https://hacktoberfest.com/), please add the `hacktoberfest-accepted` once this PR is approved. Thanks!