### PR TITLE
chore: use older lombok version for runelite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ def runeLiteVersion = '1.9.2'
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.slf4j:slf4j-simple:2.0.3'


### PR DESCRIPTION
Runelite is using lombok `1.18.20`, so can downgrade to match, and avoid the dependency verification [problem](https://github.com/runelite/plugin-hub/actions/runs/3323518501/jobs/5493960414)