### PR TITLE
fix chat message parsing when rsn has nbsp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.gauntlet'
-version = '1.2.0'
+version = '1.2.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Players with a space in their rsn were not having tracked resources updated.
This fixes this bug by simplifying chat message parsing.