### PR TITLE
Adding option to track resources upwards, rather than downward

### DIFF
--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -111,9 +111,18 @@ public interface TheGauntletConfig extends Config
 	}
 
 	@ConfigItem(
+			name = "Tracking Style",
+			description = "Choose whether to count resources upwards or downwards",
+			position = 1,
+			keyName = "trackingStyle",
+			section = resourceTrackingSection
+	)
+	default TrackingStyle trackingStyle() {return TrackingStyle.DOWNWARD;}
+
+	@ConfigItem(
 		name = "Ore",
 		description = "The desired number of ores to acquire.",
-		position = 1,
+		position = 2,
 		keyName = "resourceOre",
 		section = resourceTrackingSection
 	)
@@ -125,7 +134,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Phren bark",
 		description = "The desired number of phren barks to acquire.",
-		position = 2,
+		position = 3,
 		keyName = "resourceBark",
 		section = resourceTrackingSection
 	)
@@ -137,7 +146,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Linum tirinum",
 		description = "The desired number of linum tirinums to acquire.",
-		position = 3,
+		position = 4,
 		keyName = "resourceTirinum",
 		section = resourceTrackingSection
 	)
@@ -149,7 +158,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Grym leaf",
 		description = "The desired number of grym leaves to acquire.",
-		position = 4,
+		position = 5,
 		keyName = "resourceGrym",
 		section = resourceTrackingSection
 	)
@@ -161,7 +170,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Weapon frames",
 		description = "The desired number of weapon frames to acquire.",
-		position = 5,
+		position = 6,
 		keyName = "resourceFrame",
 		section = resourceTrackingSection
 	)
@@ -173,7 +182,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Paddlefish",
 		description = "The desired number of paddlefish to acquire.",
-		position = 6,
+		position = 7,
 		keyName = "resourcePaddlefish",
 		section = resourceTrackingSection
 	)
@@ -185,7 +194,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Crystal shards",
 		description = "The desired number of crystal shards to acquire.",
-		position = 7,
+		position = 8,
 		keyName = "resourceShard",
 		section = resourceTrackingSection
 	)
@@ -197,7 +206,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Bowstring",
 		description = "Whether or not to acquire the crystalline or corrupted bowstring.",
-		position = 8,
+		position = 9,
 		keyName = "resourceBowstring",
 		section = resourceTrackingSection
 	)
@@ -209,7 +218,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Spike",
 		description = "Whether or not to acquire the crystal or corrupted spike.",
-		position = 9,
+		position = 10,
 		keyName = "resourceSpike",
 		section = resourceTrackingSection
 	)
@@ -221,7 +230,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Orb",
 		description = "Whether or not to acquire the crystal or corrupted orb.",
-		position = 10,
+		position = 11,
 		keyName = "resourceOrb",
 		section = resourceTrackingSection
 	)
@@ -871,6 +880,19 @@ public interface TheGauntletConfig extends Config
 		{
 			return name;
 		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	enum TrackingStyle
+	{
+		UPWARD("Upward"),
+		DOWNWARD("Downward");
+
+		private final String name;
+
+		@Override
+		public String toString(){ return name;}
 	}
 
 }

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -113,7 +113,7 @@ public interface TheGauntletConfig extends Config
 	@ConfigItem(
 		name = "Tracking Mode",
 		description = "Increment or decrement resource counters." +
-			"Disable a counter by setting value to 0.",
+			"<br>Disable a counter by setting value to 0.",
 		position = 1,
 		keyName = "resourceTrackingMode",
 		section = resourceTrackingSection

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -111,13 +111,17 @@ public interface TheGauntletConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Tracking Style",
-			description = "Choose whether to count resources upwards or downwards",
-			position = 1,
-			keyName = "trackingStyle",
-			section = resourceTrackingSection
+		name = "Tracking Mode",
+		description = "Increment or decrement resource counters." +
+			"Disable a counter by setting value to 0.",
+		position = 1,
+		keyName = "resourceTrackingMode",
+		section = resourceTrackingSection
 	)
-	default TrackingStyle trackingStyle() {return TrackingStyle.DOWNWARD;}
+	default TrackingMode resourceTrackingMode()
+	{
+		return TrackingMode.DECREMENT;
+	}
 
 	@ConfigItem(
 		name = "Ore",
@@ -505,7 +509,8 @@ public interface TheGauntletConfig extends Config
 
 	@ConfigItem(
 		name = "Dynamically remove overlays",
-		description = "Remove overlays for acquired tracked resources.",
+		description = "Remove overlays for acquired tracked resources." +
+			"<br>Disabled if incrementally tracking resources.",
 		position = 20,
 		keyName = "resourceRemoveOutlineOnceAcquired",
 		section = resourceOverlaySection
@@ -884,15 +889,18 @@ public interface TheGauntletConfig extends Config
 
 	@Getter
 	@AllArgsConstructor
-	enum TrackingStyle
+	enum TrackingMode
 	{
-		UPWARD("Upward"),
-		DOWNWARD("Downward");
+		DECREMENT("Decrement"),
+		INCREMENT("Increment");
 
 		private final String name;
 
 		@Override
-		public String toString(){ return name;}
+		public String toString()
+		{
+			return name;
+		}
 	}
 
 }

--- a/src/main/java/ca/gauntlet/module/maze/MazeModule.java
+++ b/src/main/java/ca/gauntlet/module/maze/MazeModule.java
@@ -208,6 +208,7 @@ public class MazeModule implements Module
 					}
 					break;
 				case "resourceTracker":
+				case "resourceTrackingMode":
 					resourceManager.reset();
 					resourceManager.init();
 					break;

--- a/src/main/java/ca/gauntlet/module/maze/MazeOverlay.java
+++ b/src/main/java/ca/gauntlet/module/maze/MazeOverlay.java
@@ -101,9 +101,7 @@ class MazeOverlay extends Overlay
 				continue;
 			}
 
-			if (config.resourceTracker() &&
-				config.resourceRemoveOutlineOnceAcquired() &&
-				resourceManager.hasAcquiredResource(resourceEntity))
+			if (resourceManager.hasAcquiredResource(resourceEntity))
 			{
 				continue;
 			}

--- a/src/main/java/ca/gauntlet/module/maze/MinimapOverlay.java
+++ b/src/main/java/ca/gauntlet/module/maze/MinimapOverlay.java
@@ -75,32 +75,28 @@ class MinimapOverlay extends Overlay
 		}
 	}
 
-	private void renderMinimapResourceIcons(final Graphics2D graphics2D, final Collection<ResourceEntity> resources)
+	private void renderMinimapResourceIcons(final Graphics2D graphics2D, final Collection<ResourceEntity> resourceEntities)
 	{
-		if (resources.isEmpty())
+		if (resourceEntities.isEmpty())
 		{
 			return;
 		}
 
-		for (final ResourceEntity resource : resources)
+		for (final ResourceEntity resourceEntity : resourceEntities)
 		{
-			if (config.resourceTracker() &&
-				config.resourceRemoveOutlineOnceAcquired() &&
-				resourceManager.hasAcquiredResource(resource))
+			if (resourceManager.hasAcquiredResource(resourceEntity))
 			{
 				continue;
 			}
 
-			final Point point = resource.getMinimapPoint();
+			final Point point = resourceEntity.getMinimapPoint();
 
 			if (point == null)
 			{
 				continue;
 			}
 
-			OverlayUtil.renderImageLocation(graphics2D, point, resource.getMinimapIcon());
+			OverlayUtil.renderImageLocation(graphics2D, point, resourceEntity.getMinimapIcon());
 		}
 	}
-
-
 }

--- a/src/main/java/ca/gauntlet/module/maze/ResourceCounter.java
+++ b/src/main/java/ca/gauntlet/module/maze/ResourceCounter.java
@@ -51,18 +51,18 @@ class ResourceCounter extends InfoBox
 	private int count;
 	private String text;
 
-	@Inject
 	private TheGauntletConfig config;
 
 
 	ResourceCounter(final Resource resource, final BufferedImage bufferedImage, final int count,
-					final TheGauntletPlugin plugin, final ResourceManager resourceManager)
+					final TheGauntletConfig config, final TheGauntletPlugin plugin, final ResourceManager resourceManager)
 	{
 		super(bufferedImage, plugin);
 
 		this.resource = resource;
 		this.resourceManager = resourceManager;
 		this.count = count;
+		this.config = config;
 		text = String.valueOf(count);
 
 		setPriority(getPriority(resource));
@@ -145,8 +145,10 @@ class ResourceCounter extends InfoBox
 				return config.resourceShard();
 			case RAW_PADDLEFISH:
 				return config.resourcePaddlefish();
+			case WEAPON_FRAME:
+				return config.resourceFrame();
 			default:
-				return 0;
+				return 1000; //Do not turn green
 		}
 	}
 }

--- a/src/main/java/ca/gauntlet/module/maze/ResourceCounter.java
+++ b/src/main/java/ca/gauntlet/module/maze/ResourceCounter.java
@@ -27,15 +27,20 @@
 
 package ca.gauntlet.module.maze;
 
+import ca.gauntlet.TheGauntletConfig;
 import ca.gauntlet.TheGauntletPlugin;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.ui.overlay.infobox.InfoBox;
 import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
 
+import javax.inject.Inject;
+
+@Slf4j
 class ResourceCounter extends InfoBox
 {
 	@Getter(AccessLevel.PACKAGE)
@@ -45,6 +50,10 @@ class ResourceCounter extends InfoBox
 	@Getter(AccessLevel.PACKAGE)
 	private int count;
 	private String text;
+
+	@Inject
+	private TheGauntletConfig config;
+
 
 	ResourceCounter(final Resource resource, final BufferedImage bufferedImage, final int count,
 					final TheGauntletPlugin plugin, final ResourceManager resourceManager)
@@ -68,6 +77,9 @@ class ResourceCounter extends InfoBox
 	@Override
 	public Color getTextColor()
 	{
+		if (count >= resourceTarget() && config.trackingStyle() == TheGauntletConfig.TrackingStyle.UPWARD) {
+			return Color.GREEN;
+		}
 		return Color.WHITE;
 	}
 
@@ -111,6 +123,30 @@ class ResourceCounter extends InfoBox
 				return InfoBoxPriority.NONE;
 			default:
 				return InfoBoxPriority.LOW;
+		}
+	}
+	private int resourceTarget() {
+		switch (resource)
+		{
+			case CRYSTAL_ORE:
+			case CORRUPTED_ORE:
+				return config.resourceOre();
+			case PHREN_BARK:
+			case CORRUPTED_PHREN_BARK:
+				return config.resourceBark();
+			case LINUM_TIRINUM:
+			case CORRUPTED_LINUM_TIRINUM:
+				return config.resourceTirinum();
+			case GRYM_LEAF:
+			case CORRUPTED_GRYM_LEAF:
+				return config.resourceGrym();
+			case CRYSTAL_SHARDS:
+			case CORRUPTED_SHARDS:
+				return config.resourceShard();
+			case RAW_PADDLEFISH:
+				return config.resourcePaddlefish();
+			default:
+				return 0;
 		}
 	}
 }

--- a/src/main/java/ca/gauntlet/module/maze/ResourceManager.java
+++ b/src/main/java/ca/gauntlet/module/maze/ResourceManager.java
@@ -103,7 +103,6 @@ class ResourceManager
 
 	void parseChatMessage(final String chatMessage)
 	{
-		log.debug("Parsing chat message: " + chatMessage);
 		if (!config.resourceTracker() || region == Region.UNKNOWN)
 		{
 			return;
@@ -155,14 +154,12 @@ class ResourceManager
 
 	private void processNpcResource(final String parsedMessage)
 	{
-		log.debug("processing npc resource");
 		final String noTagsMessage = Text.removeTags(parsedMessage);
 
 		final Matcher matcher = PATTERN_RESOURCE_DROP.matcher(noTagsMessage);
 
 		if (!matcher.matches())
 		{
-			log.debug("Failed to match resource");
 			return;
 		}
 
@@ -170,7 +167,6 @@ class ResourceManager
 
 		if (name == null)
 		{
-			log.debug("Name is null");
 			return;
 		}
 
@@ -178,7 +174,6 @@ class ResourceManager
 
 		if (resource == null || !resources.contains(resource))
 		{
-			log.debug("resource is null or untracked");
 			return;
 		}
 
@@ -186,7 +181,6 @@ class ResourceManager
 
 		final int count = quantity != null ? Integer.parseInt(quantity) : 1;
 
-		log.debug("About to process resource");
 		processResource(resource, count);
 	}
 
@@ -226,7 +220,6 @@ class ResourceManager
 
 	private void processResource(final Resource resource, final int count)
 	{
-		log.debug("Processing Resource: " + "RESOURCE: " + resource.toString() + " COUNT: " + count);
 		if (resources.add(resource))
 		{
 			final ResourceCounter resourceCounter = new ResourceCounter(

--- a/src/main/java/ca/gauntlet/module/maze/ResourceManager.java
+++ b/src/main/java/ca/gauntlet/module/maze/ResourceManager.java
@@ -233,6 +233,7 @@ class ResourceManager
 				resource,
 				itemManager.getImage(resource.getItemId()),
 				count,
+				config,
 				plugin,
 				this
 			);


### PR DESCRIPTION
This provides a configuration value in the resource tracking section which allows the counter to move upward rather than down

While the tracker is set to upward: 
All counters with a configuration value greater than 0 are initialized at 0 at the start of the gauntlet and count up as the player collects them. The text of the counter turns green when the player has collected their configured amount of resources

While the tracker is set to downward:
Current behavior is unchanged