### PR TITLE
Add option to disable boss room entry when holding uncooked fish

### DIFF
--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -589,7 +589,7 @@ public interface TheGauntletConfig extends Config
 
 	@ConfigItem(
 			name = "Prevent entry with uncooked fish",
-			description = "Deprioritizes \"Pass\" and \"Quick-Pass\" while carrying uncooked paddlefish.<br>" + "Disable any custom menu-entry swaps as custom menu-entry swaps will take priority.",
+			description = "Removes \"Pass\" and \"Quick-Pass\" while carrying uncooked paddlefish.",
 			position = 3,
 			keyName = "utilitiesFishCheck",
 			section = utilitiesSection

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -587,6 +587,19 @@ public interface TheGauntletConfig extends Config
 		return Color.MAGENTA;
 	}
 
+	@ConfigItem(
+			name = "Prevent entry with uncooked fish",
+			description = "Deprioritizes \"Pass\" and \"Quick-Pass\" while carrying uncooked paddlefish.<br>" + "Disable any custom menu-entry swaps as custom menu-entry swaps will take priority.",
+			position = 3,
+			keyName = "utilitiesFishCheck",
+			section = utilitiesSection
+	)
+	default boolean utilitiesFishCheck()
+	{
+		return false;
+	}
+
+
 	// Hunllef Section
 
 	@ConfigItem(

--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -588,11 +588,11 @@ public interface TheGauntletConfig extends Config
 	}
 
 	@ConfigItem(
-			name = "Prevent entry with uncooked fish",
-			description = "Removes \"Pass\" and \"Quick-Pass\" while carrying uncooked paddlefish.",
-			position = 3,
-			keyName = "utilitiesFishCheck",
-			section = utilitiesSection
+		name = "Prevent entry with uncooked fish",
+		description = "Removes \"Pass\" and \"Quick-Pass\" while carrying uncooked paddlefish.",
+		position = 3,
+		keyName = "utilitiesFishCheck",
+		section = utilitiesSection
 	)
 	default boolean utilitiesFishCheck()
 	{

--- a/src/main/java/ca/gauntlet/module/maze/MazeModule.java
+++ b/src/main/java/ca/gauntlet/module/maze/MazeModule.java
@@ -31,12 +31,11 @@ import ca.gauntlet.TheGauntletConfig;
 import ca.gauntlet.module.Module;
 import ca.gauntlet.module.overlay.TimerOverlay;
 import java.awt.Color;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.Arrays;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.AccessLevel;
@@ -44,12 +43,13 @@ import lombok.Getter;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+import static net.runelite.api.ItemID.RAW_PADDLEFISH;
+import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.ObjectID;
-import net.runelite.api.MenuEntry;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.InventoryID;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameObjectDespawned;
@@ -57,8 +57,8 @@ import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
-import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.events.PostMenuSort;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.EventBus;
@@ -68,8 +68,6 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.game.npcoverlay.HighlightedNpc;
 import net.runelite.client.game.npcoverlay.NpcOverlayService;
 import net.runelite.client.ui.overlay.OverlayManager;
-
-import static net.runelite.api.ItemID.RAW_PADDLEFISH;
 
 @Singleton
 public final class MazeModule implements Module
@@ -205,7 +203,7 @@ public final class MazeModule implements Module
 	}
 
 	@Subscribe
-	public void onPostMenuSort(PostMenuSort postMenuSort)
+	public void onPostMenuSort(final PostMenuSort postMenuSort)
 	{
 		if ((!config.utilitiesFishCheck()) || client.isMenuOpen())
 		{
@@ -224,9 +222,9 @@ public final class MazeModule implements Module
 		}
 
 		// Remove Quick-pass and Pass
-		MenuEntry[] filteredEntires = Arrays.stream(client.getMenuEntries())
-				.filter(x->!x.getOption().equals("Quick-pass") && !x.getOption().equals("Pass"))
-				.toArray(MenuEntry[]::new);
+		final MenuEntry[] filteredEntires = Arrays.stream(client.getMenuEntries())
+			.filter(x -> !x.getOption().equals("Quick-pass") && !x.getOption().equals("Pass"))
+			.toArray(MenuEntry[]::new);
 
 		client.setMenuEntries(filteredEntires);
 	}


### PR DESCRIPTION
I kept forgetting to cook the fish before entering the boss. This PR adds an option to completely disable the Pass/Quick-Pass options so it is impossible to enter with uncooked fish.