### PR TITLE
Hunllef Attack Overlay Tracker

### DIFF
--- a/src/main/java/ca/gauntlet/TheGauntletConfig.java
+++ b/src/main/java/ca/gauntlet/TheGauntletConfig.java
@@ -893,6 +893,15 @@ public interface TheGauntletConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+			position = 10,
+			keyName = "bossOverlay",
+			name = "Boss Counter",
+			description = "Displays the player's and Boss' attack counts to easily track prayer/weapon switches",
+			section = hunllefSection
+	)
+	default boolean bossCounterOverlay() { return false; }
+
 	// Constants
 
 	@Getter

--- a/src/main/java/ca/gauntlet/TheGauntletPlugin.java
+++ b/src/main/java/ca/gauntlet/TheGauntletPlugin.java
@@ -39,9 +39,11 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.NPC;
+import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -72,6 +74,8 @@ public final class TheGauntletPlugin extends Plugin
 
 	private ArrayList<Integer> hunIds = new ArrayList<>(3);
 	private int hunPrayerIdCount = 1;
+	private int animationChangedCounter = 0;
+	private static final int MAX_ANIMATION_CHANGED_COUNT = 3;
 
 	@Provides
 	TheGauntletConfig provideConfig(final ConfigManager configManager)
@@ -149,13 +153,21 @@ public final class TheGauntletPlugin extends Plugin
 	@Subscribe
 	void onAnimationChanged(final AnimationChanged event)
 	{
+		if(animationChangedCounter >= MAX_ANIMATION_CHANGED_COUNT)
+			return;
+
+		animationChangedCounter++;
+
 		if (event.getActor() instanceof NPC)
 		{
 			final NPC npc = (NPC) event.getActor();
 
 			if(npc != null && hunIds.contains(npc.getId()) && hunPrayerIdCount < 2)
+			{
 				hunPrayerIdCount++;
-			else if (hunPrayerIdCount == 2 && npc != null && (npc.getId() == 9035 || npc.getId() == 9036 || npc.getId() == 9037))
+				animationChangedCounter++;
+			}
+			else if (hunPrayerIdCount == 2 && npc != null && (hunIds.contains(npc.getId())))
 			{
 				bossModule.currentNPC = npc;
 				hunPrayerIdCount++;

--- a/src/main/java/ca/gauntlet/TheGauntletPlugin.java
+++ b/src/main/java/ca/gauntlet/TheGauntletPlugin.java
@@ -189,4 +189,5 @@ public final class TheGauntletPlugin extends Plugin
 
 	public void resetIdCount() { hunPrayerIdCount = 0; }
 	public void resetHunIdCount() { hunPrayerIdCount = 1; }
+	public void resetAnimCount() { animationChangedCounter = 0; }
 }

--- a/src/main/java/ca/gauntlet/TheGauntletPlugin.java
+++ b/src/main/java/ca/gauntlet/TheGauntletPlugin.java
@@ -30,6 +30,7 @@
 
 package ca.gauntlet;
 
+import ca.gauntlet.module.boss.BossCounter;
 import ca.gauntlet.module.boss.BossModule;
 import ca.gauntlet.module.maze.MazeModule;
 import com.google.inject.Provides;
@@ -66,6 +67,8 @@ public final class TheGauntletPlugin extends Plugin
 	private MazeModule mazeModule;
 	@Inject
 	private BossModule bossModule;
+	@Inject
+	private BossCounter bossCounter;
 
 	private ArrayList<Integer> hunIds = new ArrayList<>(3);
 	private int hunPrayerIdCount = 1;
@@ -135,6 +138,14 @@ public final class TheGauntletPlugin extends Plugin
 		}
 	}
 
+	/*
+	Once again, for some reason when you spawn into the gaunlent the ID of the boss will always be default a.k.a
+	CORRUPTED_HUNLLEFF/9035. After it does it's 'Awakening' animation, the game will correctly update the boss' ID
+	to what it is currently praying. This function SHOULD only run three times.
+	 - Once to ignore the random default ID
+	 - Once again to get the proper ID
+	 - Lastly it will run again, updating the currentNPC in the BossModule class, as well as getting its current prayer.
+	 */
 	@Subscribe
 	void onAnimationChanged(final AnimationChanged event)
 	{
@@ -148,6 +159,18 @@ public final class TheGauntletPlugin extends Plugin
 			{
 				bossModule.currentNPC = npc;
 				hunPrayerIdCount++;
+				switch(npc.getId())
+				{
+					case 9035:
+						bossCounter.setBossCurrentPrayer("MELEE");
+						break;
+					case 9036:
+						bossCounter.setBossCurrentPrayer("RANGE");
+						break;
+					case 9037:
+						bossCounter.setBossCurrentPrayer("MAGIC");
+						break;
+				}
 			}
 		}
 	}

--- a/src/main/java/ca/gauntlet/TheGauntletPlugin.java
+++ b/src/main/java/ca/gauntlet/TheGauntletPlugin.java
@@ -69,13 +69,6 @@ public final class TheGauntletPlugin extends Plugin
 	private MazeModule mazeModule;
 	@Inject
 	private BossModule bossModule;
-	@Inject
-	private BossCounter bossCounter;
-
-	private ArrayList<Integer> hunIds = new ArrayList<>(3);
-	private int hunPrayerIdCount = 1;
-	private int animationChangedCounter = 0;
-	private static final int MAX_ANIMATION_CHANGED_COUNT = 3;
 
 	@Provides
 	TheGauntletConfig provideConfig(final ConfigManager configManager)
@@ -86,8 +79,6 @@ public final class TheGauntletPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
-		final List<Integer> hunIds = List.of(9035, 9036, 9037);
-
 		if (client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
@@ -141,53 +132,4 @@ public final class TheGauntletPlugin extends Plugin
 			}
 		}
 	}
-
-	/*
-	Once again, for some reason when you spawn into the gaunlent the ID of the boss will always be default a.k.a
-	CORRUPTED_HUNLLEFF/9035. After it does it's 'Awakening' animation, the game will correctly update the boss' ID
-	to what it is currently praying. This function SHOULD only run three times.
-	 - Once to ignore the random default ID
-	 - Once again to get the proper ID
-	 - Lastly it will run again, updating the currentNPC in the BossModule class, as well as getting its current prayer.
-	 */
-	@Subscribe
-	void onAnimationChanged(final AnimationChanged event)
-	{
-		if(animationChangedCounter >= MAX_ANIMATION_CHANGED_COUNT)
-			return;
-
-		animationChangedCounter++;
-
-		if (event.getActor() instanceof NPC)
-		{
-			final NPC npc = (NPC) event.getActor();
-
-			if(npc != null && hunIds.contains(npc.getId()) && hunPrayerIdCount < 2)
-			{
-				hunPrayerIdCount++;
-				animationChangedCounter++;
-			}
-			else if (hunPrayerIdCount == 2 && npc != null && (hunIds.contains(npc.getId())))
-			{
-				bossModule.currentNPC = npc;
-				hunPrayerIdCount++;
-				switch(npc.getId())
-				{
-					case 9035:
-						bossCounter.setBossCurrentPrayer("MELEE");
-						break;
-					case 9036:
-						bossCounter.setBossCurrentPrayer("RANGE");
-						break;
-					case 9037:
-						bossCounter.setBossCurrentPrayer("MAGIC");
-						break;
-				}
-			}
-		}
-	}
-
-	public void resetIdCount() { hunPrayerIdCount = 0; }
-	public void resetHunIdCount() { hunPrayerIdCount = 1; }
-	public void resetAnimCount() { animationChangedCounter = 0; }
 }

--- a/src/main/java/ca/gauntlet/module/boss/BossCounter.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossCounter.java
@@ -1,9 +1,8 @@
 package ca.gauntlet.module.boss;
 
 import ca.gauntlet.TheGauntletConfig;
-import ca.gauntlet.TheGauntletPlugin;
 import lombok.Getter;
-import net.runelite.client.plugins.Plugin;
+import lombok.Setter;
 import net.runelite.client.ui.overlay.*;
 
 import javax.inject.Inject;
@@ -20,7 +19,9 @@ public class BossCounter extends Overlay
     @Getter
     private int playerAttackCount = 0;
     @Getter
-    private String bossPrayer = "RANGE";
+    private String bossAttackStyle = "RANGE";
+    @Getter @Setter
+    private String bossCurrentPrayer = "";
 
     @Inject
     private BossCounter(final TheGauntletConfig config)
@@ -50,10 +51,10 @@ public class BossCounter extends Overlay
         OverlayUtil.renderTextLocation(graphics, playerPoint, playerAttacks, Color.WHITE);
         OverlayUtil.renderTextLocation(graphics, reqPoint, reqPrayer, Color.WHITE);
 
-        if(bossPrayer.equals("RANGE"))
-            OverlayUtil.renderTextLocation(graphics, prayPoint, bossPrayer, Color.GREEN);
-        else if(bossPrayer.equals("MAGIC"))
-            OverlayUtil.renderTextLocation(graphics, prayPoint, bossPrayer, Color.BLUE);
+        if(bossAttackStyle.equals("RANGE"))
+            OverlayUtil.renderTextLocation(graphics, prayPoint, bossAttackStyle, Color.GREEN);
+        else if(bossAttackStyle.equals("MAGIC"))
+            OverlayUtil.renderTextLocation(graphics, prayPoint, bossAttackStyle, Color.BLUE);
 
         return null;
     }
@@ -73,17 +74,9 @@ public class BossCounter extends Overlay
             resetPlayerAttackCount();
     }
 
-    void updateBossPrayer(String prayer)
-    {
-        bossPrayer = prayer;
-    }
-    void resetPlayerAttackCount()
-    {
-        playerAttackCount = 0;
-    }
-    void resetBossAttackCount()
-    {
-        bossAttackCount = 0;
-    }
-    void resetPrayer() { bossPrayer = "RANGE"; }
+    void updateBossAttackStyle(String prayer) { bossAttackStyle = prayer; }
+    void resetPrayer() { bossAttackStyle = "RANGE"; }
+    void resetPlayerAttackCount() { playerAttackCount = 0; }
+    void resetBossAttackCount() { bossAttackCount = 0; }
+
 }

--- a/src/main/java/ca/gauntlet/module/boss/BossCounter.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossCounter.java
@@ -18,10 +18,6 @@ public class BossCounter extends Overlay
     private int bossAttackCount = 0;
     @Getter
     private int playerAttackCount = 0;
-    @Getter
-    private String bossAttackStyle = "RANGE";
-    @Getter @Setter
-    private String bossCurrentPrayer = "";
 
     @Inject
     private BossCounter(final TheGauntletConfig config)
@@ -40,21 +36,11 @@ public class BossCounter extends Overlay
 
         String playerAttacks = "Player Attacks: " + playerAttackCount;
         String hunlleffAttacks = "Boss Attacks: " + bossAttackCount;
-        String reqPrayer = "You need to pray: ";
 
         net.runelite.api.Point hunlleffPoint = new net.runelite.api.Point(10, 160);
         net.runelite.api.Point playerPoint = new net.runelite.api.Point(10, 170);
-        net.runelite.api.Point reqPoint = new net.runelite.api.Point(10, 200);
-        net.runelite.api.Point prayPoint = new net.runelite.api.Point(100, 200);
-
         OverlayUtil.renderTextLocation(graphics, hunlleffPoint, hunlleffAttacks, Color.WHITE);
         OverlayUtil.renderTextLocation(graphics, playerPoint, playerAttacks, Color.WHITE);
-        OverlayUtil.renderTextLocation(graphics, reqPoint, reqPrayer, Color.WHITE);
-
-        if(bossAttackStyle.equals("RANGE"))
-            OverlayUtil.renderTextLocation(graphics, prayPoint, bossAttackStyle, Color.GREEN);
-        else if(bossAttackStyle.equals("MAGIC"))
-            OverlayUtil.renderTextLocation(graphics, prayPoint, bossAttackStyle, Color.BLUE);
 
         return null;
     }
@@ -74,8 +60,6 @@ public class BossCounter extends Overlay
             resetPlayerAttackCount();
     }
 
-    void updateBossAttackStyle(String prayer) { bossAttackStyle = prayer; }
-    void resetPrayer() { bossAttackStyle = "RANGE"; }
     void resetPlayerAttackCount() { playerAttackCount = 0; }
     void resetBossAttackCount() { bossAttackCount = 0; }
 

--- a/src/main/java/ca/gauntlet/module/boss/BossCounter.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossCounter.java
@@ -42,9 +42,9 @@ public class BossCounter extends Overlay
         String hunlleffAttacks = "Boss Attacks: " + bossAttackCount;
         String reqPrayer = "You need to pray: ";
 
-        net.runelite.api.Point hunlleffPoint = new net.runelite.api.Point(10, 160); // Adjust the position as needed
-        net.runelite.api.Point playerPoint = new net.runelite.api.Point(10, 170); // Adjust the position as needed
-        net.runelite.api.Point reqPoint = new net.runelite.api.Point(10, 200); // Adjust the position as needed
+        net.runelite.api.Point hunlleffPoint = new net.runelite.api.Point(10, 160);
+        net.runelite.api.Point playerPoint = new net.runelite.api.Point(10, 170);
+        net.runelite.api.Point reqPoint = new net.runelite.api.Point(10, 200);
         net.runelite.api.Point prayPoint = new net.runelite.api.Point(100, 200);
 
         OverlayUtil.renderTextLocation(graphics, hunlleffPoint, hunlleffAttacks, Color.WHITE);

--- a/src/main/java/ca/gauntlet/module/boss/BossCounter.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossCounter.java
@@ -1,0 +1,89 @@
+package ca.gauntlet.module.boss;
+
+import ca.gauntlet.TheGauntletConfig;
+import ca.gauntlet.TheGauntletPlugin;
+import lombok.Getter;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.*;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.awt.*;
+
+@Singleton
+public class BossCounter extends Overlay
+{
+    private final TheGauntletConfig config;
+
+    @Getter
+    private int bossAttackCount = 0;
+    @Getter
+    private int playerAttackCount = 0;
+    @Getter
+    private String bossPrayer = "RANGE";
+
+    @Inject
+    private BossCounter(final TheGauntletConfig config)
+    {
+        this.config = config;
+        setPosition(OverlayPosition.DYNAMIC);
+        setPriority(OverlayPriority.HIGH);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        if(!config.bossCounterOverlay())
+            return null;
+
+        String playerAttacks = "Player Attacks: " + playerAttackCount;
+        String hunlleffAttacks = "Boss Attacks: " + bossAttackCount;
+        String reqPrayer = "You need to pray: ";
+
+        net.runelite.api.Point hunlleffPoint = new net.runelite.api.Point(10, 160); // Adjust the position as needed
+        net.runelite.api.Point playerPoint = new net.runelite.api.Point(10, 170); // Adjust the position as needed
+        net.runelite.api.Point reqPoint = new net.runelite.api.Point(10, 200); // Adjust the position as needed
+        net.runelite.api.Point prayPoint = new net.runelite.api.Point(100, 200);
+
+        OverlayUtil.renderTextLocation(graphics, hunlleffPoint, hunlleffAttacks, Color.WHITE);
+        OverlayUtil.renderTextLocation(graphics, playerPoint, playerAttacks, Color.WHITE);
+        OverlayUtil.renderTextLocation(graphics, reqPoint, reqPrayer, Color.WHITE);
+
+        if(bossPrayer.equals("RANGE"))
+            OverlayUtil.renderTextLocation(graphics, prayPoint, bossPrayer, Color.GREEN);
+        else if(bossPrayer.equals("MAGIC"))
+            OverlayUtil.renderTextLocation(graphics, prayPoint, bossPrayer, Color.BLUE);
+
+        return null;
+    }
+
+
+    void incrementBossAttack()
+    {
+        bossAttackCount++;
+        if(bossAttackCount == 4)
+            resetBossAttackCount();
+    }
+
+    void incrementPlayerAttackCount()
+    {
+        playerAttackCount++;
+        if (playerAttackCount == 6)
+            resetPlayerAttackCount();
+    }
+
+    void updateBossPrayer(String prayer)
+    {
+        bossPrayer = prayer;
+    }
+    void resetPlayerAttackCount()
+    {
+        playerAttackCount = 0;
+    }
+    void resetBossAttackCount()
+    {
+        bossAttackCount = 0;
+    }
+    void resetPrayer() { bossPrayer = "RANGE"; }
+}

--- a/src/main/java/ca/gauntlet/module/boss/BossModule.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossModule.java
@@ -156,6 +156,9 @@ public final class BossModule implements Module
 			final NPC npc = (NPC) event.getActor();
 			currentNPC = npc;
 
+			if(npc == null)
+				return;
+
 			switch (npc.getAnimation())
 			{
 				case 8418:
@@ -174,6 +177,8 @@ public final class BossModule implements Module
 			final Player player = (Player) event.getActor();
 			final int playerAnimation = player.getAnimation();
 
+			if(currentNPC == null)
+				return;
 			// First if statement is checking that the players attack is valid enough to be counted
 			// e.a. We attack with melee and the boss is NOT praying melee (it can pray magic or range)
 			if ((playerAnimation == 428 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF)) ||

--- a/src/main/java/ca/gauntlet/module/boss/BossModule.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossModule.java
@@ -72,8 +72,6 @@ public final class BossModule implements Module
 	private BossOverlay bossOverlay;
 	@Inject
 	private BossCounter bossCounter;
-	@Inject
-	private TheGauntletPlugin theGauntletPlugin;
 	private String lastKnownPrayer = "MAGIX"; // Temp as this will change on entering the gauntlent.
 	public NPC currentNPC;
 
@@ -98,10 +96,6 @@ public final class BossModule implements Module
 		overlayManager.remove(bossCounter);
 		bossCounter.resetBossAttackCount();
 		bossCounter.resetPlayerAttackCount();
-		bossCounter.resetPrayer();
-		theGauntletPlugin.resetAnimCount();
-		theGauntletPlugin.resetIdCount();
-		theGauntletPlugin.resetHunIdCount();
 		timerOverlay.reset();
 		tornadoes.clear();
 	}
@@ -166,11 +160,6 @@ public final class BossModule implements Module
 				case 8419:
 					bossCounter.incrementBossAttack();
 					break;
-				case 8754:
-					bossCounter.updateBossAttackStyle("MAGIC");
-					break;
-				case 8755:
-					bossCounter.updateBossAttackStyle("RANGE");
 			}
 		}
 		else if (event.getActor() instanceof Player)
@@ -180,23 +169,10 @@ public final class BossModule implements Module
 
 			if(currentNPC == null)
 				return;
-			// First if statement is checking that the players attack is valid enough to be counted
-			// e.a. We attack with melee and the boss is NOT praying melee (it can pray magic or range)
 			if ((playerAnimation == 428 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF)) ||
 					(playerAnimation == 426 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF_9036)) ||
 					(playerAnimation == 1167 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF_9037)))
 			{
-				/* Sometimes this game is stupid and doesn't count the attack animation:
-				 - if the player splashes with magic it will never count this attack though the animation played. I guess
-				 the animation is only registered on a hit.
-				 - if the player attacks too quickly entering the room, the animationID from entering the doorway will
-				 override the attack animation, so the attack is never registered though we did attack.
-
-				The following if statements account for the edge case that any attack style wasn't accounted for at some point during
-				the fight. It checks the current prayer that the boss is praying, and compares it to the lastKnownPrayer. If the lastKnownPrayer
-				is different from what it is currently praying, then at some point an attack from the player wasn't registered. We update
-				the last known prayer to what the boss is currently praying, and reset the player attack count as it will be out of sync if any of these cases pass.
-				 */
 				if(currentNPC.getId() == NpcID.CORRUPTED_HUNLLEF && (!lastKnownPrayer.equals("MELEE")))
 				{
 					bossCounter.resetPlayerAttackCount();

--- a/src/main/java/ca/gauntlet/module/boss/BossModule.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossModule.java
@@ -180,14 +180,16 @@ public final class BossModule implements Module
 					(playerAnimation == 426 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF_9036)) ||
 					(playerAnimation == 1167 && (currentNPC.getId() != NpcID.CORRUPTED_HUNLLEF_9037)))
 			{
-				/* Sometimes this game is stupid and doesn't count the attack animation (if the player splashes with magic it
-				will never count this attack though the animation played. I guess the animation is only registered on a hit).
+				/* Sometimes this game is stupid and doesn't count the attack animation:
+				 - if the player splashes with magic it will never count this attack though the animation played. I guess
+				 the animation is only registered on a hit.
+				 - if the player attacks too quickly entering the room, the animationID from entering the doorway will
+				 override the attack animation, so the attack is never registered though we did attack.
 
-				These if statements account for the edge case that any attack style wasn't accounted for at some point. It checks
-				the current prayer the boss is prayer, and compares it to the lastKnownPrayer. If the lastKnownPrayer is different
-				from what it is currently praying, then at some point an attack from the player wasn't registered. We update
-				the last known prayer to what the boss is currently praying, and reset the player attack count as it will
-				be out of sync if any of these cases pass.
+				The following if statements account for the edge case that any attack style wasn't accounted for at some point during
+				the fight. It checks the current prayer that the boss is praying, and compares it to the lastKnownPrayer. If the lastKnownPrayer
+				is different from what it is currently praying, then at some point an attack from the player wasn't registered. We update
+				the last known prayer to what the boss is currently praying, and reset the player attack count as it will be out of sync if any of these cases pass.
 				 */
 				if(currentNPC.getId() == NpcID.CORRUPTED_HUNLLEF && (!lastKnownPrayer.equals("MELEE")))
 				{

--- a/src/main/java/ca/gauntlet/module/boss/BossModule.java
+++ b/src/main/java/ca/gauntlet/module/boss/BossModule.java
@@ -99,6 +99,7 @@ public final class BossModule implements Module
 		bossCounter.resetBossAttackCount();
 		bossCounter.resetPlayerAttackCount();
 		bossCounter.resetPrayer();
+		theGauntletPlugin.resetAnimCount();
 		theGauntletPlugin.resetIdCount();
 		theGauntletPlugin.resetHunIdCount();
 		timerOverlay.reset();


### PR DESCRIPTION
A very small QOL change that when fighting hunllef, the player will be able to see how many attacks they have performed, how many attacks hunllef has attacked, and the current prayer they should be using. 